### PR TITLE
Allow for empty email

### DIFF
--- a/src/components/GravatarImg.vue
+++ b/src/components/GravatarImg.vue
@@ -10,7 +10,8 @@
 
     props: {
       email: {
-        type: String
+        type: String,
+        default: ''
       },
 
       hash: {


### PR DESCRIPTION
This is necessary for dynamic binding, for example using computed values that update at runtime, but may be initially empty.