### PR TITLE
be sure that protocol matches http or https

### DIFF
--- a/src/components/GravatarImg.vue
+++ b/src/components/GravatarImg.vue
@@ -56,9 +56,13 @@
 
     computed: {
       url() {
-        const protocol = this.protocol.slice(-1) === ':'
+        var protocol = this.protocol.slice(-1) === ':'
           ? this.protocol
           : `${this.protocol}:`;
+
+        if(protocol !== 'http:' && protocol !== 'https:'){
+          protocol = 'https:'
+        }
 
         const img = [
           `${protocol === ':' ? '' : protocol}//www.gravatar.com/avatar/`,


### PR DESCRIPTION
I've used the component inside a browser extensions, the protocol was moz-extension:// or chrome-extension:// so the gravatar will never render. I think even Electron will have the same problem. 

This fix will allow the use even with these other protocols.